### PR TITLE
Fix for main menu infinite load + reduce stutters when destroying badniks

### DIFF
--- a/SonicMania/Objects/Global/DialogRunner.c
+++ b/SonicMania/Objects/Global/DialogRunner.c
@@ -83,40 +83,27 @@ void DialogRunner_HandleCallback(void)
 
 void DialogRunner_NotifyAutoSave_CB(void)
 {
-    printf("here! %s:%u\n", __FILE__, __LINE__);
     DialogRunner->isAutoSaving = false;
     globals->notifiedAutosave  = true;
-    printf("here! %s:%u\n", __FILE__, __LINE__);
     UIWaitSpinner_FinishWait();
-    printf("here! %s:%u\n", __FILE__, __LINE__);
 }
 
 void DialogRunner_NotifyAutoSave(void)
 {
-    printf("here! %s:%u\n", __FILE__, __LINE__);
     RSDK_THIS(DialogRunner);
-    printf("here! %s:%u\n", __FILE__, __LINE__);
 
     String string;
-    printf("here! %s:%u\n", __FILE__, __LINE__);
     INIT_STRING(string);
-    printf("here! %s:%u\n", __FILE__, __LINE__);
 
     if (DialogRunner->isAutoSaving) {
-        printf("here! %s:%u\n", __FILE__, __LINE__);
         if (!UIDialog->activeDialog) {
-            printf("here! %s:%u\n", __FILE__, __LINE__);
             Localization_GetString(&string, STR_AUTOSAVENOTIF);
-            printf("here! %s:%u\n", __FILE__, __LINE__);
             EntityUIDialog *dialog = UIDialog_CreateDialogOk(&string, DialogRunner_NotifyAutoSave_CB, true);
-            printf("here! %s:%u\n", __FILE__, __LINE__);
             dialog->useAltColor    = true;
         }
     }
     else {
-        printf("here! %s:%u\n", __FILE__, __LINE__);
         DialogRunner->activeCallback = NULL;
-        printf("here! %s:%u\n", __FILE__, __LINE__);
         destroyEntity(self);
     }
 }

--- a/SonicMania/Objects/Global/Player.c
+++ b/SonicMania/Objects/Global/Player.c
@@ -2543,10 +2543,12 @@ bool32 Player_CheckBadnikBreak(EntityPlayer *player, void *e, bool32 destroy)
             }
 
 #if MANIA_USE_PLUS
+#if !defined(_arch_dreamcast) // Avoids freezes when destroying badniks
             StatInfo info;
             TimeAttackData_TrackEnemyDefeat(&info, Zone_GetZoneID(), Zone->actID, characterID, SceneInfo->filter == (FILTER_BOTH | FILTER_ENCORE),
                                             FROM_FIXED(badnik->position.x), FROM_FIXED(badnik->position.y));
             API.TryTrackStat(&info);
+#endif
 #else
             APICallback_TrackEnemyDefeat(Zone_GetZoneID(), Zone->actID, characterID, FROM_FIXED(badnik->position.x), FROM_FIXED(badnik->position.y));
 #endif

--- a/SonicMania/Objects/Menu/ManiaModeMenu.c
+++ b/SonicMania/Objects/Menu/ManiaModeMenu.c
@@ -80,8 +80,12 @@ bool32 ManiaModeMenu_InitAPI(void)
             if (MenuSetup->initializedAPI)
                 return true;
 
+#if defined(_arch_dreamcast) // TimeAttack is disabled, so it would hang because the last two bools are never set
+            if (globals->optionsLoaded == STATUS_OK && globals->saveLoaded == STATUS_OK) {
+#else
             if (globals->optionsLoaded == STATUS_OK && globals->saveLoaded == STATUS_OK && globals->replayTableLoaded == STATUS_OK
                 && globals->taTableLoaded == STATUS_OK) {
+#endif
 
                 if (!API_GetNoSave() && DialogRunner_NotifyAutosave())
                     return false;

--- a/SonicMania/Objects/Menu/UIWaitSpinner.c
+++ b/SonicMania/Objects/Menu/UIWaitSpinner.c
@@ -107,7 +107,6 @@ void UIWaitSpinner_FinishWait(void)
     }
     else {
         if (!spinner) {
-            printf("here! %s:%u\n", __FILE__, __LINE__);
             spinner              = CREATE_ENTITY(UIWaitSpinner, NULL, 0, 0);
             spinner->isPermanent = true;
 


### PR DESCRIPTION
Allows us to go in the main menu, but there's still too much VRAM allocations going on to be stable.

![image](https://github.com/user-attachments/assets/da255c42-2bcb-44bb-993e-045483de0c5a)

Bonus commit for reducing stutters when destroying badniks (disables stat tracking log).