### PR TITLE
Use right branch for RSDKv5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,4 @@
 [submodule "dependencies/RSDKv5"]
 	path = dependencies/RSDKv5
 	url = https://github.com/michael-fadely/RSDKv5-Decompilation
+	branch = "sf94/dreamcast-kallistios-pvr"


### PR DESCRIPTION
Makes it so --recursive clones sf94/dreamcast-kallistios-pvr instead of the main branch