### PR TITLE
Implement missing visual effects on Dreamcast

### DIFF
--- a/SonicMania/Objects/Common/ParallaxSprite.c
+++ b/SonicMania/Objects/Common/ParallaxSprite.c
@@ -74,6 +74,7 @@ void ParallaxSprite_Draw(void)
 #endif
     RSDK.DrawSprite(&self->animator, &drawPos, true);
 }
+
 void ParallaxSprite_Create(void *data)
 {
     RSDK_THIS(ParallaxSprite);

--- a/SonicMania/Objects/Common/ParallaxSprite.c
+++ b/SonicMania/Objects/Common/ParallaxSprite.c
@@ -56,9 +56,24 @@ void ParallaxSprite_Draw(void)
         RSDK.GetFrame(ParallaxSprite->aniFrames, self->aniID, 0)->sprX = self->sprX + ((self->xSpeed + (Zone->timer << self->timerSpeed)) & 0x7F);
     }
 
+#if _arch_dreamcast
+    // this makes the waves appear in the INK_MASKED parallax layer on CPZ2
+    if (self->attribute == PARALLAXSPRITE_ATTR_SHIFT) {
+        float oldDepth = RSDK.GetDepth();
+        int32 oldClipX1 = screen->clipBound_X1;
+        int32 oldClipY1 = screen->clipBound_Y1;
+        int32 oldClipX2 = screen->clipBound_X2;
+        int32 oldClipY2 = screen->clipBound_Y2;
+        RSDK.SetDepth(1.06f);
+        RSDK.SetClipBounds(SceneInfo->currentScreenID, 0, 0, ScreenInfo->size.x, ScreenInfo->size.y);
+        RSDK.DrawSprite(&self->animator, &drawPos, true);
+        RSDK.SetClipBounds(SceneInfo->currentScreenID, oldClipX1, oldClipY1, oldClipX2, oldClipY2);
+        RSDK.SetDepth(oldDepth);
+    }
+    else
+#endif
     RSDK.DrawSprite(&self->animator, &drawPos, true);
 }
-
 void ParallaxSprite_Create(void *data)
 {
     RSDK_THIS(ParallaxSprite);
@@ -128,9 +143,16 @@ void ParallaxSprite_Create(void *data)
             self->sprX       = RSDK.GetFrame(ParallaxSprite->aniFrames, self->aniID, 1)->sprX;
             self->timerSpeed = ZONE_RAND(0, 2);
             self->xSpeed     = ZONE_RAND(0, 128);
-            self->inkEffect  = INK_MASKED;
-            self->visible    = true;
-            self->state      = NULL;
+#if _arch_dreamcast
+            // this makes the waves appear in the INK_MASKED parallax layer on CPZ2
+            self->inkEffect = INK_NONE;
+            self->alpha = 0xFF;
+            self->drawGroup = Zone->fgDrawGroup[0];
+#else
+            self->inkEffect = INK_MASKED;
+#endif
+            self->visible = true;
+            self->state   = NULL;
             break;
     }
 

--- a/SonicMania/Objects/OOZ/Smog.c
+++ b/SonicMania/Objects/OOZ/Smog.c
@@ -87,10 +87,7 @@ void Smog_Draw(void)
 #if _arch_dreamcast
     // INK_BLEND doesn't produce great results on DC
     // this looks ok
-    if (self->alpha >= 0x60)
-        RSDK.DrawDeformedSprite(Smog->aniFrames, INK_ALPHA, 0x60);
-    else
-        RSDK.DrawDeformedSprite(Smog->aniFrames, INK_ALPHA, self->alpha);
+    RSDK.DrawDeformedSprite(Smog->aniFrames, INK_ALPHA, MIN(0x60, self->alpha));
 #else
     if (self->alpha >= 0x80)
         RSDK.DrawDeformedSprite(Smog->aniFrames, INK_BLEND, 0xE0);

--- a/SonicMania/Objects/OOZ/Smog.c
+++ b/SonicMania/Objects/OOZ/Smog.c
@@ -84,10 +84,19 @@ void Smog_Draw(void)
         scanlineID++;
     }
 
+#if _arch_dreamcast
+    // INK_BLEND doesn't produce great results on DC
+    // this looks ok
+    if (self->alpha >= 0x60)
+        RSDK.DrawDeformedSprite(Smog->aniFrames, INK_ALPHA, 0x60);
+    else
+        RSDK.DrawDeformedSprite(Smog->aniFrames, INK_ALPHA, self->alpha);
+#else
     if (self->alpha >= 0x80)
         RSDK.DrawDeformedSprite(Smog->aniFrames, INK_BLEND, 0xE0);
     else
         RSDK.DrawDeformedSprite(Smog->aniFrames, INK_ALPHA, self->alpha);
+#endif
 }
 
 void Smog_Create(void *data)

--- a/SonicMania/Objects/Title/TitleBG.c
+++ b/SonicMania/Objects/Title/TitleBG.c
@@ -9,6 +9,28 @@
 
 ObjectTitleBG *TitleBG;
 
+#if _arch_dreamcast
+// colors from the graphics used for the original INK_MASKED effect
+static const uint32 cycleColors[7] = {
+    0x8060E0, 0xA080E0, 0xB090E0, 0x0068F0, 0x28A8F0, 0x68D0F0, 0x98E0F0,
+};
+
+// 32 step color cycle: purple, light purple, blue ,light blue and back again
+static const int32 colorMap[32] = {
+    0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 1, 1, 1, 1,
+    0, 3, 3, 3, 4, 4, 4, 5, 5, 5, 5, 6, 6, 4, 4, 4,
+};
+
+static const uint8 fringeIndices[] = {
+    62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,
+    90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,
+    114,115,116,117,118,119,120,121,122,123,124,125,126,127,
+    45,46,47,152,162,163,167,172,173,174,245,246
+};
+
+static int32 wingTimer = 0;
+#endif
+
 void TitleBG_Update(void)
 {
     RSDK_THIS(TitleBG);
@@ -43,6 +65,21 @@ void TitleBG_StaticUpdate(void)
         TitleBG->palTimer = 0;
         RSDK.RotatePalette(0, 140, 143, false);
     }
+
+#ifdef _arch_dreamcast
+    // reproduce the original color cycle INK_MASKED effect on the fringe of the wings
+    // done by patching the sprite sheet when it gets loaded
+    // with a run of previously unused palette indices to replace the mask color
+    // here we update the palette indices to do the color cycle effect
+    // not 100% accurate but REALLY CLOSE
+
+    wingTimer--;
+
+    for (int32 i = 0; i < 78; i++) {
+        int32 phase = ((i + (wingTimer >> 1)) & 31);
+        RSDK.SetPaletteEntry(0, fringeIndices[i], cycleColors[colorMap[phase]]);
+    }
+#endif // _arch_dreamcast
 }
 
 void TitleBG_Draw(void)
@@ -142,6 +179,13 @@ void TitleBG_Scanline_Island(ScanlineInfo *scanlines)
     int32 sine   = RSDK.Sin1024(-TitleBG->angle) >> 2;
     int32 cosine = RSDK.Cos1024(-TitleBG->angle) >> 2;
 
+#if _arch_dreamcast
+    scanlines->deform.x = SCANLINE_MAJOR_MAGIC_3DTILES;
+    scanlines->deform.y = SCANLINE_MINOR_MAGIC_ISLAND;
+    scanlines->position.x = sine;
+    scanlines->position.y = cosine;
+    scanlines++;
+#else
     ScanlineInfo *scanlinePtr = &scanlines[168];
     for (int32 i = 16; i < 88; ++i) {
         int32 id  = 0xA00000 / (8 * i);
@@ -154,6 +198,7 @@ void TitleBG_Scanline_Island(ScanlineInfo *scanlines)
         scanlinePtr->position.x = sin - ScreenInfo->center.x * scanlinePtr->deform.x - 0xA000 * sine + 0x2000000;
         ++scanlinePtr;
     }
+#endif
 }
 
 #if GAME_INCLUDE_EDITOR

--- a/SonicMania/Objects/Title/TitleBG.c
+++ b/SonicMania/Objects/Title/TitleBG.c
@@ -184,7 +184,6 @@ void TitleBG_Scanline_Island(ScanlineInfo *scanlines)
     scanlines->deform.y = SCANLINE_MINOR_MAGIC_ISLAND;
     scanlines->position.x = sine;
     scanlines->position.y = cosine;
-    scanlines++;
 #else
     ScanlineInfo *scanlinePtr = &scanlines[168];
     for (int32 i = 16; i < 88; ++i) {


### PR DESCRIPTION
**OOZ Smog (DrawDeformedSprite):** Implements the DC path for DrawDeformedSprite using horizontal strip quads on the TR (translucent) list. Each 4-pixel strip samples the scanline deformation table at its midpoint for UV displacement. Uses proper fixed-to-float conversion (dividing by 65536.0f instead of FROM_FIXED integer truncation). Smog uses INK_ALPHA at 0x60 instead of the unsupported INK_BLEND.

**CPZ2 ParallaxSprite SHIFT (INK_MASKED workaround):** On DC, draws the scrolling wave sprites behind the foreground at a lower Z depth instead of using INK_MASKED. The foreground tiles' transparent regions let the waves show through. Expands clip bounds before drawing to prevent premature culling when the sprite scrolls partially offscreen.

**Title Screen Wing Shine:** Patches the wing emblem sprite at load time, replacing the mask-color palette index (55) with per-row palette indices from unused palette slots. Each frame, cycles those palette entries through a 7-color purple/blue gradient with a 32-step pattern, recreating the animated shimmer that the original achieves via INK_MASKED with a large sprite overlay.