### PR TITLE
fix slide sound effect issue on OOZ1

### DIFF
--- a/SonicMania/Objects/Global/Soundboard.c
+++ b/SonicMania/Objects/Global/Soundboard.c
@@ -49,8 +49,12 @@ void Soundboard_StaticUpdate(void)
                 Soundboard->sfxIsPlaying[s]    = false;
                 Soundboard->sfxPlayingTimer[s] = 0;
             }
-            else if (Soundboard->sfxFadeOutDuration[s] > 0 && Soundboard->sfxChannel[s] > 0) {
-                if (Soundboard->sfxFadeOutTimer[s] >= Soundboard->sfxFadeOutDuration[s]) {
+#if _arch_dreamcast
+    else if (Soundboard->sfxFadeOutDuration[s] > 0 && Soundboard->sfxChannel[s] >= 0) {
+#else
+    else if (Soundboard->sfxFadeOutDuration[s] > 0 && Soundboard->sfxChannel[s] > 0) {
+#endif
+    if (Soundboard->sfxFadeOutTimer[s] >= Soundboard->sfxFadeOutDuration[s]) {
                     RSDK.StopSfx(Soundboard->sfxList[s]);
                 }
                 else {

--- a/SonicMania/Objects/Global/Soundboard.c
+++ b/SonicMania/Objects/Global/Soundboard.c
@@ -50,11 +50,11 @@ void Soundboard_StaticUpdate(void)
                 Soundboard->sfxPlayingTimer[s] = 0;
             }
 #if _arch_dreamcast
-    else if (Soundboard->sfxFadeOutDuration[s] > 0 && Soundboard->sfxChannel[s] >= 0) {
+            else if (Soundboard->sfxFadeOutDuration[s] > 0 && Soundboard->sfxChannel[s] >= 0) {
 #else
-    else if (Soundboard->sfxFadeOutDuration[s] > 0 && Soundboard->sfxChannel[s] > 0) {
+            else if (Soundboard->sfxFadeOutDuration[s] > 0 && Soundboard->sfxChannel[s] > 0) {
 #endif
-    if (Soundboard->sfxFadeOutTimer[s] >= Soundboard->sfxFadeOutDuration[s]) {
+                if (Soundboard->sfxFadeOutTimer[s] >= Soundboard->sfxFadeOutDuration[s]) {
                     RSDK.StopSfx(Soundboard->sfxList[s]);
                 }
                 else {


### PR DESCRIPTION
`RSDK.PlaySfx` must not have returned `0` as a valid sfx channel in the original Mania audio code.

The KOS version does. That's why that Slide sound effect on OOZ1 would never stop.

This fixes that.