### PR TITLE
fix new visual glitch on Blue Sphere Stages

### DIFF
--- a/SonicMania/Objects/BSS/BSS_Setup.c
+++ b/SonicMania/Objects/BSS/BSS_Setup.c
@@ -40,8 +40,9 @@ void BSS_Setup_Update(void)
 
 #if _arch_dreamcast
     // 1ms sleep gives the PVR time to finish the previous frame's render
-    // before palette RAM is modified — without this, rare one-frame
-    // checkerboard inversions occur when palettePage toggles
+    // before palette RAM is modified
+    // without this, occasional single frame checkerboard inversions occur
+    // when palettePage toggles and the screen flickers
     thd_sleep(1);
 
     // debounce on the palettePage value

--- a/SonicMania/Objects/BSS/BSS_Setup.c
+++ b/SonicMania/Objects/BSS/BSS_Setup.c
@@ -7,6 +7,9 @@
 
 #include "Game.h"
 #include <time.h>
+#if _arch_dreamcast
+#include <kos/thread.h>
+#endif
 
 ObjectBSS_Setup *BSS_Setup;
 
@@ -36,6 +39,11 @@ void BSS_Setup_Update(void)
     ScreenInfo->position.x = 0x100 - ScreenInfo->center.x;
 
 #if _arch_dreamcast
+    // 1ms sleep gives the PVR time to finish the previous frame's render
+    // before palette RAM is modified — without this, rare one-frame
+    // checkerboard inversions occur when palettePage toggles
+    thd_sleep(1);
+
     // debounce on the palettePage value
     // update the paletteLine value to use
     // only when updating the debounced palettePage


### PR DESCRIPTION
add a tiny delay so palette is consistent on right turns

there was a glitch on the right side of the screen when you turn right and I narrowed it down to the timing between frames and palette updates.

noticed it went away with a printf in place, replaced that with a `thd_sleep(1)`